### PR TITLE
Update CI test matrix to lts/1/pre structure

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,9 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - 'lts'
           - '1'
-          - 'nightly'
+          - 'pre'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["ChrisRackauckas <contact@chrisrackauckas.com>"]
 version = "0.1.0"
 
 [compat]
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
This PR updates the CI testing matrix to follow modern SciML conventions.

## Changes
- Updated CI test matrix to use:
  - `lts` - Long-term support version (currently Julia 1.10)
  - `1` - Latest stable Julia 1.x
  - `pre` - Pre-release/nightly builds
- Updated minimum Julia version in Project.toml to 1.10 (current LTS)

## Rationale
- `lts` provides stability testing on the long-term support version
- `1` tests on the current stable release
- `pre` catches potential issues with upcoming Julia versions
- This follows the standard SciML CI conventions