### PR TITLE
Raise PrecompileTools compat floor to 1.2 to fix Downgrade CI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 [compat]
 ExplicitImports = "1.14.0"
 JET = "0.9, 0.10, 0.11"
-PrecompileTools = "1"
+PrecompileTools = "1.2"
 julia = "1.10"
 
 [extras]

--- a/src/LightweightStats.jl
+++ b/src/LightweightStats.jl
@@ -426,15 +426,17 @@ function cov(X::AbstractMatrix; dims::Int = 1, corrected::Bool = true)
         n == 0 && return fill(oftype(real(zero(eltype(X))) / 1, NaN), p, p)
 
         means = vec(mean(X; dims = 1))
-        C = zeros(float(real(eltype(X))), p, p)
-
-        # Center the data once using broadcasting
-        X_centered = X .- means'
+        Tc = float(eltype(X))
+        C = zeros(Tc, p, p)
 
         for i in 1:p
+            mi = means[i]
             for j in i:p
-                # Use views and broadcasting for column operations
-                s = sum(view(X_centered, :, i) .* _conj(view(X_centered, :, j)))
+                mj = means[j]
+                s = zero(Tc)
+                for k in 1:n
+                    s += (X[k, i] - mi) * _conj(X[k, j] - mj)
+                end
                 C[i, j] = corrected ? s / (n - 1) : s / n
                 if i != j
                     C[j, i] = _conj(C[i, j])
@@ -443,19 +445,21 @@ function cov(X::AbstractMatrix; dims::Int = 1, corrected::Bool = true)
         end
         return C
     elseif dims == 2
-        n, p = size(X')
+        p, n = size(X)
         n == 0 && return fill(oftype(real(zero(eltype(X))) / 1, NaN), p, p)
 
         means = vec(mean(X; dims = 2))
-        C = zeros(float(real(eltype(X))), p, p)
-
-        # Center the data once using broadcasting
-        X_centered = X .- means
+        Tc = float(eltype(X))
+        C = zeros(Tc, p, p)
 
         for i in 1:p
+            mi = means[i]
             for j in i:p
-                # Use views and broadcasting for row operations
-                s = sum(view(X_centered, i, :) .* _conj(view(X_centered, j, :)))
+                mj = means[j]
+                s = zero(Tc)
+                for k in 1:n
+                    s += (X[i, k] - mi) * _conj(X[j, k] - mj)
+                end
                 C[i, j] = corrected ? s / (n - 1) : s / n
                 if i != j
                     C[j, i] = _conj(C[i, j])

--- a/test/regression_tests.jl
+++ b/test/regression_tests.jl
@@ -208,6 +208,19 @@ using Random
         end
     end
 
+    @testset "cov - complex matrices" begin
+        # Off-diagonal covariances are genuinely complex here, so the result
+        # matrix must have a complex eltype (regression for an InexactError when
+        # the result was allocated as a real matrix).
+        Xc = ComplexF64[1 + 1im 2 + 3im; 3 - 1im 4 + 2im; 5 + 0im 6 - 1im]
+        for dims in (1, 2)
+            C_lw = LightweightStats.cov(Xc; dims = dims)
+            C_st = Statistics.cov(Xc; dims = dims)
+            @test eltype(C_lw) <: Complex
+            @test C_lw ≈ C_st
+        end
+    end
+
     @testset "cor - correlation vectors" begin
         x = randn(30)
         y = randn(30)


### PR DESCRIPTION
## Problem

This PR fixes two `main` CI failures for LightweightStats.jl on the `1` channel (now Julia 1.12) / JET 0.11.

### 1. Downgrade Tests resolution failure

The **Downgrade Tests** job on `main` failed to resolve the test environment:

```
ERROR: LoadError: Unsatisfiable requirements detected for package ExplicitImports [7d51a73a]:
 ├─restricted to versions 1.14.0-1 by project
 └─restricted by compatibility requirements with PrecompileTools [aea7be01]
   to versions: 1.0.0-1.8.0 or uninstalled — no versions left
     └─restricted to versions 1.0.0 by an explicit requirement
```

**Root cause:** `ExplicitImports` 1.13+ requires `PrecompileTools = "1.2.0 - 1"`, but this package declared `PrecompileTools = "1"` (floor `1.0.0`). The downgrade job pins every `[compat]` dep to its floor, pinning `PrecompileTools` to `1.0.0`, which forces `ExplicitImports <= 1.8.0` — unsatisfiable against the declared `ExplicitImports = "1.14.0"` floor.

**Fix:** Raise the compat floor to `PrecompileTools = "1.2"`. PrecompileTools 1.2 supports `julia >= 1.6`, so the package's `julia = "1.10"` floor and the `@compile_workload` usage are unaffected.

### 2. JET static-analysis failures (JET 0.11 / Julia 1.12)

The `JET error analysis`, `JET analysis with different numeric types`, and `JET analysis with complex numbers` testsets failed with 4 reports, all originating from `cov(::Matrix)` (and `cor(::Matrix)`, which calls it). Each report bottomed out at the same Julia-1.12 LinearAlgebra inference artifact: broadcasting (`.*`) over two contiguous matrix-column `SubArray`s forces broadcast's `unaliascopy` path through `copyto_unaliased!` in LinearAlgebra `transpose.jl`, where inference yields a `Union{Adjoint{T,Union{}}, Transpose{T,Union{}}}` and JET flags an "invalid builtin getfield". This reproduces in a ~7-line standalone function with no package code (a Julia/LinearAlgebra false positive), but is straightforward to avoid in source.

**Fix:** Rewrite both `cov` branches to accumulate each covariance entry with an explicit index loop over the centered values instead of broadcasting over column/row views. This sidesteps the `unaliascopy` path entirely — JET now reports zero issues for both `report_call` and `report_opt` — and also removes the per-pair temporary allocation.

**Latent bug also fixed:** the result matrix was allocated as `zeros(float(real(eltype(X))), p, p)` — a real matrix even for complex input. Whenever an off-diagonal covariance was genuinely complex, assigning it into the real array threw `InexactError`. The result is now `zeros(float(eltype(X)), ...)`, matching `Statistics.cov`. A regression test for complex covariance matrices was added.

## Local verification

Julia 1.12.6 (the `1` channel) full suite, with JET 0.11.4:

```
LightweightStats.jl |  455    455   (0 fail)   # was 447 pass / 4 fail before the JET fix
```

All `report_call` / `report_opt` entry points from `jet_tests.jl` return zero reports on 1.12. Julia 1.10.11 floor full suite: 422 pass / 1 pre-existing broken (the gated JET `@test_skip`), no regressions. Complex `cov` verified against `Statistics.cov` for a matrix with genuinely-complex off-diagonals (matches; old code threw `InexactError`).

Downgrade resolve (Julia 1.10.11): `PrecompileTools=1.0.0` fails (unsatisfiable), `PrecompileTools=1.2.0` resolves and loads cleanly.

Please ignore until reviewed by @ChrisRackauckas.
